### PR TITLE
86c1ab0yq: Remove accepted ride requests with drivers after assigning for the ride

### DIFF
--- a/taxi-restapi-common-module/src/main/java/by/dudkin/common/util/KafkaConstants.java
+++ b/taxi-restapi-common-module/src/main/java/by/dudkin/common/util/KafkaConstants.java
@@ -9,5 +9,9 @@ public final class KafkaConstants {
 
     public static final String RIDE_REQUESTS_TOPIC = "ride-requests";
     public static final String AVAILABLE_DRIVERS_TOPIC = "available-drivers";
+    public static final String ACCEPTED_RIDES_TOPIC = "accepted-rides";
+
+    public static final int PARTITIONS_COUNT = 1;
+    public static final int REPLICAS_COUNT = 1;
 
 }

--- a/taxi-restapi-driver-service/src/main/java/by/dudkin/driver/configuration/KafkaSerializationConfiguration.java
+++ b/taxi-restapi-driver-service/src/main/java/by/dudkin/driver/configuration/KafkaSerializationConfiguration.java
@@ -1,0 +1,18 @@
+package by.dudkin.driver.configuration;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.support.converter.StringJsonMessageConverter;
+
+/**
+ * @author Alexander Dudkin
+ */
+@Configuration
+public class KafkaSerializationConfiguration {
+
+    @Bean
+    public StringJsonMessageConverter stringJsonMessageConverter() {
+        return new StringJsonMessageConverter();
+    }
+
+}

--- a/taxi-restapi-driver-service/src/main/java/by/dudkin/driver/kafka/producer/AvailableDriverProducer.java
+++ b/taxi-restapi-driver-service/src/main/java/by/dudkin/driver/kafka/producer/AvailableDriverProducer.java
@@ -1,5 +1,6 @@
 package by.dudkin.driver.kafka.producer;
 
+import by.dudkin.common.util.KafkaConstants;
 import by.dudkin.driver.rest.dto.request.AvailableDriver;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -18,16 +19,13 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class AvailableDriverProducer {
 
-    @Value("${spring.kafka.topic.name.available-drivers}")
-    private String availableDriversTopic;
-
     private final KafkaTemplate<String, AvailableDriver> kafkaTemplate;
 
     public void sendMessage(AvailableDriver driver) {
         log.info("Json message send -> {}", driver.toString());
         Message<AvailableDriver> message = MessageBuilder
             .withPayload(driver)
-            .setHeader(KafkaHeaders.TOPIC, availableDriversTopic)
+            .setHeader(KafkaHeaders.TOPIC, KafkaConstants.AVAILABLE_DRIVERS_TOPIC)
             .build();
         kafkaTemplate.send(message);
     }

--- a/taxi-restapi-notification-service/src/main/java/by/dudkin/notification/config/KafkaSerializationConfiguration.java
+++ b/taxi-restapi-notification-service/src/main/java/by/dudkin/notification/config/KafkaSerializationConfiguration.java
@@ -8,7 +8,7 @@ import org.springframework.kafka.support.converter.StringJsonMessageConverter;
  * @author Alexander Dudkin
  */
 @Configuration
-public class KafkaConfig {
+public class KafkaSerializationConfiguration {
 
     @Bean
     public StringJsonMessageConverter stringJsonMessageConverter() {

--- a/taxi-restapi-notification-service/src/main/java/by/dudkin/notification/kafka/AcceptedRideConsumer.java
+++ b/taxi-restapi-notification-service/src/main/java/by/dudkin/notification/kafka/AcceptedRideConsumer.java
@@ -1,0 +1,29 @@
+package by.dudkin.notification.kafka;
+
+import by.dudkin.common.util.KafkaConstants;
+import by.dudkin.notification.kafka.domain.AcceptedRide;
+import by.dudkin.notification.service.NotificationService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author Alexander Dudkin
+ */
+@Slf4j
+@Component
+public class AcceptedRideConsumer {
+
+    private final NotificationService notificationService;
+
+    public AcceptedRideConsumer(NotificationService notificationService) {
+        this.notificationService = notificationService;
+    }
+
+    @KafkaListener(topics = KafkaConstants.ACCEPTED_RIDES_TOPIC)
+    public void consume(AcceptedRide ride) {
+        log.info("Json message received -> {}", ride.toString());
+        notificationService.removeAcceptedRide(ride);
+    }
+
+}

--- a/taxi-restapi-notification-service/src/main/java/by/dudkin/notification/kafka/domain/AcceptedRide.java
+++ b/taxi-restapi-notification-service/src/main/java/by/dudkin/notification/kafka/domain/AcceptedRide.java
@@ -1,0 +1,6 @@
+package by.dudkin.notification.kafka.domain;
+
+/**
+ * @author Alexander Dudkin
+ */
+public record AcceptedRide(long rideId, long driverId, long carId) {}

--- a/taxi-restapi-notification-service/src/main/java/by/dudkin/notification/service/NotificationService.java
+++ b/taxi-restapi-notification-service/src/main/java/by/dudkin/notification/service/NotificationService.java
@@ -2,8 +2,13 @@ package by.dudkin.notification.service;
 
 import by.dudkin.common.util.ErrorMessages;
 import by.dudkin.notification.domain.RideRequest;
+import by.dudkin.notification.kafka.domain.AcceptedRide;
+import by.dudkin.notification.service.dao.DriverDao;
 import by.dudkin.notification.service.dao.RideDao;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataAccessException;
+import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.stereotype.Service;
 
 import java.util.Set;
@@ -15,11 +20,13 @@ import java.util.concurrent.TimeUnit;
 /**
  * @author Alexander Dudkin
  */
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class NotificationService {
 
     private final RideDao rideDao;
+    private final DriverDao driverDao;
 
     public CompletableFuture<Set<RideRequest>> getNearbyRequestsForDriverAsync(long driverId, long timeout) {
         return CompletableFuture.supplyAsync(() -> {
@@ -47,6 +54,22 @@ public class NotificationService {
                 throw new RuntimeException(ErrorMessages.GENERAL_ERROR);
             }
         });
+    }
+
+    public void removeAcceptedRide(AcceptedRide ride) {
+        try {
+            rideDao.removeAcceptedRide(ride.rideId());
+            driverDao.removeAvailableDriver(ride.driverId(), ride.carId());
+
+            log.info("Successfully removed accepted ride with ID: {} and associated driver", ride.rideId());
+        } catch (DataAccessException e) {
+            log.error("Database error while removing accepted ride with ID: {} - {}", ride.rideId(), e.getMessage());
+            if (e instanceof EmptyResultDataAccessException) {
+                log.warn("Ride or driver already removed or not found for ride ID: {}", ride.rideId());
+            } else {
+                throw new RuntimeException("Failed to remove accepted ride due to database error", e);
+            }
+        }
     }
 
 }

--- a/taxi-restapi-notification-service/src/main/java/by/dudkin/notification/service/dao/DriverDao.java
+++ b/taxi-restapi-notification-service/src/main/java/by/dudkin/notification/service/dao/DriverDao.java
@@ -30,4 +30,14 @@ public class DriverDao {
             });
     }
 
+    public void removeAvailableDriver(long driverId, long carId) {
+        jdbcTemplate.execute("delete from available_drivers " +
+            "where driver_id = ? and car_id = ?", (PreparedStatementCallback<?>) ps -> {
+            ps.setLong(1, driverId);
+            ps.setLong(2, carId);
+            ps.execute();
+            return null;
+        });
+    }
+
 }

--- a/taxi-restapi-notification-service/src/main/java/by/dudkin/notification/service/dao/RideDao.java
+++ b/taxi-restapi-notification-service/src/main/java/by/dudkin/notification/service/dao/RideDao.java
@@ -74,4 +74,13 @@ public class RideDao {
         return Collections.unmodifiableSet(requests);
     }
 
+    public void removeAcceptedRide(long rideId) {
+        jdbcTemplate.execute("delete from ride_requests " +
+            "where ride_id = ?", (PreparedStatementCallback<?>) ps -> {
+            ps.setLong(1, rideId);
+            ps.execute();
+            return null;
+        });
+    }
+
 }

--- a/taxi-restapi-rides-service/src/main/java/by/dudkin/rides/configuration/AcceptedRideProducerConfiguration.java
+++ b/taxi-restapi-rides-service/src/main/java/by/dudkin/rides/configuration/AcceptedRideProducerConfiguration.java
@@ -1,23 +1,21 @@
-package by.dudkin.driver.configuration;
+package by.dudkin.rides.configuration;
 
 import by.dudkin.common.util.KafkaConstants;
 import org.apache.kafka.clients.admin.NewTopic;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.kafka.config.TopicBuilder;
-import org.springframework.kafka.support.converter.StringJsonMessageConverter;
 
 /**
  * @author Alexander Dudkin
  */
 @Configuration
-public class AvailableDriverProducerConfig {
+public class AcceptedRideProducerConfiguration {
 
     @Bean
-    public NewTopic availableDriverTopic() {
+    public NewTopic acceptedRidesTopic() {
         return TopicBuilder
-            .name(KafkaConstants.AVAILABLE_DRIVERS_TOPIC)
+            .name(KafkaConstants.ACCEPTED_RIDES_TOPIC)
             .partitions(KafkaConstants.PARTITIONS_COUNT)
             .replicas(KafkaConstants.REPLICAS_COUNT)
             .build();

--- a/taxi-restapi-rides-service/src/main/java/by/dudkin/rides/configuration/KafkaSerializationConfiguration.java
+++ b/taxi-restapi-rides-service/src/main/java/by/dudkin/rides/configuration/KafkaSerializationConfiguration.java
@@ -1,0 +1,18 @@
+package by.dudkin.rides.configuration;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.support.converter.StringJsonMessageConverter;
+
+/**
+ * @author Alexander Dudkin
+ */
+@Configuration
+public class KafkaSerializationConfiguration {
+
+    @Bean
+    public StringJsonMessageConverter stringJsonMessageConverter() {
+        return new StringJsonMessageConverter();
+    }
+
+}

--- a/taxi-restapi-rides-service/src/main/java/by/dudkin/rides/configuration/RideProducerConfiguration.java
+++ b/taxi-restapi-rides-service/src/main/java/by/dudkin/rides/configuration/RideProducerConfiguration.java
@@ -12,26 +12,15 @@ import org.springframework.kafka.support.converter.StringJsonMessageConverter;
  * @author Alexander Dudkin
  */
 @Configuration
-public class RideProducerConfig {
-
-    @Value("${kafka.partitions.count}")
-    private int partitions;
-
-    @Value("${kafka.replicas.count}")
-    private int replicas;
+public class RideProducerConfiguration {
 
     @Bean
-    public NewTopic topic() {
+    public NewTopic rideRequestsTopic() {
         return TopicBuilder
             .name(KafkaConstants.RIDE_REQUESTS_TOPIC)
-            .partitions(partitions)
-            .replicas(replicas)
+            .partitions(KafkaConstants.PARTITIONS_COUNT)
+            .replicas(KafkaConstants.REPLICAS_COUNT)
             .build();
-    }
-
-    @Bean
-    public StringJsonMessageConverter stringJsonMessageConverter() {
-        return new StringJsonMessageConverter();
     }
 
 }

--- a/taxi-restapi-rides-service/src/main/java/by/dudkin/rides/kafka/domain/AcceptedRideEvent.java
+++ b/taxi-restapi-rides-service/src/main/java/by/dudkin/rides/kafka/domain/AcceptedRideEvent.java
@@ -1,0 +1,8 @@
+package by.dudkin.rides.kafka.domain;
+
+import java.io.Serializable;
+
+/**
+ * @author Alexander Dudkin
+ */
+public record AcceptedRideEvent(long rideId, long driverId, long carId) implements Serializable {}

--- a/taxi-restapi-rides-service/src/main/java/by/dudkin/rides/kafka/producer/AcceptedRideProducer.java
+++ b/taxi-restapi-rides-service/src/main/java/by/dudkin/rides/kafka/producer/AcceptedRideProducer.java
@@ -1,0 +1,34 @@
+package by.dudkin.rides.kafka.producer;
+
+import by.dudkin.common.util.KafkaConstants;
+import by.dudkin.rides.kafka.domain.AcceptedRideEvent;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author Alexander Dudkin
+ */
+@Slf4j
+@Component
+public class AcceptedRideProducer {
+
+    private final KafkaTemplate<String, AcceptedRideEvent> kafkaTemplate;
+
+    public AcceptedRideProducer(KafkaTemplate<String, AcceptedRideEvent> kafkaTemplate) {
+        this.kafkaTemplate = kafkaTemplate;
+    }
+
+    public void sendMessage(AcceptedRideEvent ride) {
+        log.info("Json message send -> {}", ride.toString());
+        Message<AcceptedRideEvent> message = MessageBuilder
+            .withPayload(ride)
+            .setHeader(KafkaHeaders.TOPIC, KafkaConstants.ACCEPTED_RIDES_TOPIC)
+            .build();
+        kafkaTemplate.send(message);
+    }
+
+}

--- a/taxi-restapi-rides-service/src/main/java/by/dudkin/rides/service/AcceptedRideEventListener.java
+++ b/taxi-restapi-rides-service/src/main/java/by/dudkin/rides/service/AcceptedRideEventListener.java
@@ -1,0 +1,25 @@
+package by.dudkin.rides.service;
+
+import by.dudkin.rides.kafka.domain.AcceptedRideEvent;
+import by.dudkin.rides.kafka.producer.AcceptedRideProducer;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author Alexander Dudkin
+ */
+@Component
+public class AcceptedRideEventListener {
+
+    private final AcceptedRideProducer acceptedRideProducer;
+
+    public AcceptedRideEventListener(AcceptedRideProducer acceptedRideProducer) {
+        this.acceptedRideProducer = acceptedRideProducer;
+    }
+
+    @EventListener
+    public void handleAcceptedRideEvent(AcceptedRideEvent event) {
+        acceptedRideProducer.sendMessage(event);
+    }
+
+}


### PR DESCRIPTION
### Changes

- New Kafka's topic `accepted-rides` with its producer in `Rides Service` and consumer in `Notification Service`
- After successful acceptance of a ride, information about the ride request and the available driver who accepted the ride is deleted from the database of the `Notification Service`. 

---

### Progress

- [x] Change must be properly reviewed (1 review required)
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue

- [86c1ab0yq](https://app.clickup.com/t/86c1ab0yq): Remove accepted ride requests with drivers after assigning for the ride

### Reviewers

- [Dzmitry Dzivin](https://github.com/dzmitrydzivin)
