### PR TITLE
86c1e59zb: Validate driver existence before viewing active ride requests

### DIFF
--- a/taxi-restapi-notification-service/pom.xml
+++ b/taxi-restapi-notification-service/pom.xml
@@ -40,6 +40,10 @@
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-netflix-eureka-client</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-openfeign</artifactId>
+        </dependency>
 
         <!-- Database -->
         <dependency>

--- a/taxi-restapi-notification-service/src/main/java/by/dudkin/notification/NotificationServiceApplication.java
+++ b/taxi-restapi-notification-service/src/main/java/by/dudkin/notification/NotificationServiceApplication.java
@@ -3,10 +3,12 @@ package by.dudkin.notification;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
 /**
  * @author Alexander Dudkin
  */
+@EnableFeignClients
 @EnableDiscoveryClient
 @SpringBootApplication
 public class NotificationServiceApplication {

--- a/taxi-restapi-notification-service/src/main/java/by/dudkin/notification/advice/DriverNotFoundException.java
+++ b/taxi-restapi-notification-service/src/main/java/by/dudkin/notification/advice/DriverNotFoundException.java
@@ -1,0 +1,7 @@
+package by.dudkin.notification.advice;
+
+public class DriverNotFoundException extends RuntimeException {
+    public DriverNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/taxi-restapi-notification-service/src/main/java/by/dudkin/notification/advice/RestExceptionHandler.java
+++ b/taxi-restapi-notification-service/src/main/java/by/dudkin/notification/advice/RestExceptionHandler.java
@@ -1,0 +1,61 @@
+package by.dudkin.notification.advice;
+
+import by.dudkin.common.util.ErrorMessages;
+import org.springframework.context.MessageSource;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.ProblemDetail;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.Locale;
+
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.CONFLICT;
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+import static org.springframework.http.ProblemDetail.forStatusAndDetail;
+
+/**
+ * @author Alexander Dudkin
+ */
+@RestControllerAdvice
+public class RestExceptionHandler {
+
+    private final MessageSource messageSource;
+
+    public RestExceptionHandler(MessageSource messageSource) {
+        this.messageSource = messageSource;
+    }
+
+    @ExceptionHandler(IllegalStateException.class)
+    public ResponseEntity<ProblemDetail> handleIllegalStateException(IllegalStateException e) {
+        String message = messageSource.getMessage(e.getMessage(), null, Locale.getDefault());
+        return new ResponseEntity<>(forStatusAndDetail(CONFLICT, message), CONFLICT);
+    }
+
+    @ExceptionHandler(DriverNotFoundException.class)
+    public ResponseEntity<ProblemDetail> handleDriverNotFoundException(DriverNotFoundException e) {
+        String message = messageSource.getMessage(e.getMessage(), null, Locale.getDefault());
+        return new ResponseEntity<>(forStatusAndDetail(NOT_FOUND, message), NOT_FOUND);
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ProblemDetail> handleIllegalArgumentException(IllegalArgumentException e) {
+        String message = messageSource.getMessage(e.getMessage(), null, Locale.getDefault());
+        return new ResponseEntity<>(forStatusAndDetail(BAD_REQUEST, message), BAD_REQUEST);
+    }
+
+    @ExceptionHandler(DataIntegrityViolationException.class)
+    public ResponseEntity<ProblemDetail> handleDataIntegrityViolationException(DataIntegrityViolationException e) {
+        String message = messageSource.getMessage(ErrorMessages.DATA_INTEGRITY, null, Locale.getDefault());
+        return new ResponseEntity<>(forStatusAndDetail(INTERNAL_SERVER_ERROR, message), INTERNAL_SERVER_ERROR);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ProblemDetail> handleException(Exception e) {
+        String message = messageSource.getMessage(ErrorMessages.GENERAL_ERROR, null, Locale.getDefault());
+        return new ResponseEntity<>(forStatusAndDetail(INTERNAL_SERVER_ERROR, e.getMessage()), INTERNAL_SERVER_ERROR);
+    }
+
+}

--- a/taxi-restapi-notification-service/src/main/java/by/dudkin/notification/aspect/NotificationAspect.java
+++ b/taxi-restapi-notification-service/src/main/java/by/dudkin/notification/aspect/NotificationAspect.java
@@ -1,0 +1,42 @@
+package by.dudkin.notification.aspect;
+
+import by.dudkin.common.util.ErrorMessages;
+import by.dudkin.notification.advice.DriverNotFoundException;
+import by.dudkin.notification.dto.DriverResponse;
+import by.dudkin.notification.feign.DriverClient;
+import feign.FeignException;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+
+/**
+ * @author Alexander Dudkin
+ */
+@Aspect
+@Component
+public class NotificationAspect {
+
+    private final DriverClient driverClient;
+
+    public NotificationAspect(DriverClient driverClient) {
+        this.driverClient = driverClient;
+    }
+
+    @Around("execution(* by.dudkin.notification.controller.NotificationController.getNearbyRequests(..)) && args(driverId, ..)")
+    public Object checkDriverExists(ProceedingJoinPoint joinPoint, UUID driverId) throws Throwable {
+        ResponseEntity<DriverResponse> response;
+        try {
+            response = driverClient.getDriver(driverId);
+        } catch (FeignException e) {
+            throw new DriverNotFoundException(ErrorMessages.DRIVER_NOT_FOUND);
+        } catch (Exception e) {
+            throw new RuntimeException(ErrorMessages.GENERAL_ERROR);
+        }
+        return joinPoint.proceed();
+    }
+
+}

--- a/taxi-restapi-notification-service/src/main/java/by/dudkin/notification/config/MessageSourceConfiguration.java
+++ b/taxi-restapi-notification-service/src/main/java/by/dudkin/notification/config/MessageSourceConfiguration.java
@@ -1,0 +1,35 @@
+package by.dudkin.notification.config;
+
+import org.springframework.context.MessageSource;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.support.ReloadableResourceBundleMessageSource;
+import org.springframework.web.servlet.LocaleResolver;
+import org.springframework.web.servlet.i18n.AcceptHeaderLocaleResolver;
+
+import java.util.Locale;
+
+/**
+ * @author Alexander Dudkin
+ */
+@Configuration
+public class MessageSourceConfiguration {
+
+    @Bean
+    public MessageSource messageSource() {
+        ReloadableResourceBundleMessageSource messageSource
+            = new ReloadableResourceBundleMessageSource();
+        messageSource.setBasename("classpath:messages/messages");
+        messageSource.setDefaultEncoding("UTF-8");
+        messageSource.setDefaultLocale(Locale.ENGLISH);
+        return messageSource;
+    }
+
+    @Bean
+    public LocaleResolver localeResolver() {
+        AcceptHeaderLocaleResolver resolver = new AcceptHeaderLocaleResolver();
+        resolver.setDefaultLocale(Locale.ENGLISH);
+        return resolver;
+    }
+
+}

--- a/taxi-restapi-notification-service/src/main/java/by/dudkin/notification/config/OpenFeignBearerTokenInterceptorConfiguration.java
+++ b/taxi-restapi-notification-service/src/main/java/by/dudkin/notification/config/OpenFeignBearerTokenInterceptorConfiguration.java
@@ -1,0 +1,32 @@
+package by.dudkin.notification.config;
+
+import feign.RequestInterceptor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+
+/**
+ * @author Alexander Dudkin
+ */
+@Configuration
+public class OpenFeignBearerTokenInterceptorConfiguration {
+
+    private static final String BEARER = "Bearer ";
+
+    @Bean
+    RequestInterceptor requestInterceptor() {
+        return requestTemplate -> {
+            final String authorization = HttpHeaders.AUTHORIZATION;
+            Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+            if (authentication instanceof JwtAuthenticationToken jwtAuthenticationToken) {
+                String token = jwtAuthenticationToken.getToken().getTokenValue();
+                requestTemplate.header(authorization, BEARER + token);
+            }
+        };
+    }
+
+}

--- a/taxi-restapi-notification-service/src/main/java/by/dudkin/notification/dto/DriverResponse.java
+++ b/taxi-restapi-notification-service/src/main/java/by/dudkin/notification/dto/DriverResponse.java
@@ -1,0 +1,32 @@
+package by.dudkin.notification.dto;
+
+import by.dudkin.common.entity.PersonalInfo;
+import by.dudkin.common.enums.DriverStatus;
+
+import java.io.Serializable;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+/**
+ * @author Alexander Dudkin
+ */
+public record DriverResponse(
+
+    UUID id,
+
+    PersonalInfo info,
+
+    BigDecimal balance,
+
+    DriverStatus status,
+
+    Integer experience,
+
+    Double rating,
+
+    LocalDateTime createdAt,
+
+    LocalDateTime updatedAt
+
+) implements Serializable {}

--- a/taxi-restapi-notification-service/src/main/java/by/dudkin/notification/feign/DriverClient.java
+++ b/taxi-restapi-notification-service/src/main/java/by/dudkin/notification/feign/DriverClient.java
@@ -1,0 +1,25 @@
+package by.dudkin.notification.feign;
+
+import by.dudkin.notification.config.OpenFeignBearerTokenInterceptorConfiguration;
+import by.dudkin.notification.dto.DriverResponse;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+import java.util.UUID;
+
+/**
+ * @author Alexander Dudkin
+ */
+@FeignClient(
+    value = "drivers-service",
+    path = "/api/drivers",
+    configuration = OpenFeignBearerTokenInterceptorConfiguration.class
+)
+public interface DriverClient {
+
+    @GetMapping("/{driverId}")
+    ResponseEntity<DriverResponse> getDriver(@PathVariable UUID driverId);
+
+}

--- a/taxi-restapi-notification-service/src/main/java/by/dudkin/notification/feign/FeignBadRequestExceptionHandler.java
+++ b/taxi-restapi-notification-service/src/main/java/by/dudkin/notification/feign/FeignBadRequestExceptionHandler.java
@@ -1,0 +1,18 @@
+package by.dudkin.notification.feign;
+
+import feign.FeignException;
+import feign.Response;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author Alexander Dudkin
+ */
+@Component("400")
+public class FeignBadRequestExceptionHandler implements FeignExceptionHandler {
+
+    @Override
+    public FeignException handleException(Response response) {
+        return FeignException.errorStatus(response.request().httpMethod().name(), response);
+    }
+
+}

--- a/taxi-restapi-notification-service/src/main/java/by/dudkin/notification/feign/FeignExceptionHandler.java
+++ b/taxi-restapi-notification-service/src/main/java/by/dudkin/notification/feign/FeignExceptionHandler.java
@@ -1,0 +1,11 @@
+package by.dudkin.notification.feign;
+
+import feign.FeignException;
+import feign.Response;
+
+/**
+ * @author Alexander Dudkin
+ */
+public interface FeignExceptionHandler {
+    FeignException handleException(Response response);
+}

--- a/taxi-restapi-notification-service/src/main/java/by/dudkin/notification/feign/FeignNotFoundExceptionHandler.java
+++ b/taxi-restapi-notification-service/src/main/java/by/dudkin/notification/feign/FeignNotFoundExceptionHandler.java
@@ -1,0 +1,18 @@
+package by.dudkin.notification.feign;
+
+import feign.FeignException;
+import feign.Response;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author Alexander Dudkin
+ */
+@Component("404")
+public class FeignNotFoundExceptionHandler implements FeignExceptionHandler {
+
+    @Override
+    public FeignException handleException(Response response) {
+        return FeignException.errorStatus(response.request().httpMethod().name(), response);
+    }
+
+}

--- a/taxi-restapi-notification-service/src/main/java/by/dudkin/notification/feign/RetrieveMessageErrorDecoder.java
+++ b/taxi-restapi-notification-service/src/main/java/by/dudkin/notification/feign/RetrieveMessageErrorDecoder.java
@@ -1,0 +1,33 @@
+package by.dudkin.notification.feign;
+
+import feign.Response;
+import feign.codec.ErrorDecoder;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+
+/**
+ * @author Alexander Dudkin
+ */
+@Service
+public class RetrieveMessageErrorDecoder implements ErrorDecoder {
+
+    private final Map<String, FeignExceptionHandler> feignExceptionHandlers;
+
+    public RetrieveMessageErrorDecoder(Map<String, FeignExceptionHandler> feignExceptionHandlers) {
+        this.feignExceptionHandlers = feignExceptionHandlers;
+    }
+
+    @Override
+    public Exception decode(String s, Response response) {
+        String requestUrl = response.request().url();
+        FeignExceptionHandler handler = feignExceptionHandlers.get(String.valueOf(response.status()));
+
+        if (handler != null) {
+            return handler.handleException(response);
+        }
+
+        return new RuntimeException("No handler found. Generic exception for URL: " + requestUrl);
+    }
+
+}

--- a/taxi-restapi-notification-service/src/main/resources/application.yaml
+++ b/taxi-restapi-notification-service/src/main/resources/application.yaml
@@ -2,7 +2,7 @@ server.port: 8084
 
 spring:
   profiles:
-    active: postgres, kafka
+    active: postgres, kafka, security
   application:
     name: notification-service
 


### PR DESCRIPTION
### Changes

- Add OpenFeign `DriverClient` to check whether the driver with given ID exists or not.
- Exception handling for exceptions thrown by OpenFeign.
- `RestExceptionHandler` class to handle all exceptions thrown by DispatcherServlet.

---

### Progress

- [x] Change must be properly reviewed (1 review required)
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue

- [86c1e59zb](https://app.clickup.com/t/86c1e59zb): Validate driver existence before viewing active ride requests

### Reviewers

- [Dzmitry Dzivin](https://github.com/dzmitrydzivin)
