### PR TITLE
86c1pq7t4: Refactor Geolocation Update Endpoint to Use Bearer Token Authentication

### DIFF
--- a/taxi-restapi-driver-service/src/main/java/by/dudkin/driver/rest/controller/DriverLocationRestController.java
+++ b/taxi-restapi-driver-service/src/main/java/by/dudkin/driver/rest/controller/DriverLocationRestController.java
@@ -7,6 +7,7 @@ import by.dudkin.driver.util.MetricUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -15,6 +16,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.UUID;
+
+import static by.dudkin.driver.util.TokenConstants.USERNAME_CLAIM_EXPRESSION;
 
 /**
  * @author Alexander Dudkin
@@ -27,11 +30,12 @@ public class DriverLocationRestController {
     public static final String URI = "/api/drivers";
     private final DriverLocationService driverLocationService;
 
-    @PutMapping(value = "/{driverId}/location")
+    @PutMapping(value = "/location")
     @TrackMetric(metricName = MetricUtils.DRIVERS_LOCATION_UPDATED_COUNT)
-    public ResponseEntity<Void> updateCoordinates(@PathVariable UUID driverId,
+    public ResponseEntity<Void> updateCoordinates(@AuthenticationPrincipal(expression = USERNAME_CLAIM_EXPRESSION)
+                                                  String username,
                                                   @RequestBody DriverLocation location) {
-        this.driverLocationService.update(driverId, location);
+        this.driverLocationService.update(username, location);
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
 

--- a/taxi-restapi-driver-service/src/main/java/by/dudkin/driver/service/DriverLocationService.java
+++ b/taxi-restapi-driver-service/src/main/java/by/dudkin/driver/service/DriverLocationService.java
@@ -1,7 +1,11 @@
 package by.dudkin.driver.service;
 
+import by.dudkin.common.util.ErrorMessages;
+import by.dudkin.driver.domain.Driver;
 import by.dudkin.driver.domain.DriverLocationDocument;
 import by.dudkin.driver.repository.DriverLocationRepository;
+import by.dudkin.driver.repository.DriverRepository;
+import by.dudkin.driver.rest.advice.custom.DriverNotFoundException;
 import by.dudkin.driver.util.DriverLocation;
 import lombok.AllArgsConstructor;
 import org.springframework.data.elasticsearch.core.geo.GeoPoint;
@@ -17,11 +21,24 @@ import java.util.UUID;
 public class DriverLocationService {
 
     private final DriverLocationRepository driverLocationRepository;
+    private final DriverRepository driverRepository;
 
-    public void update(UUID driverId, DriverLocation driverLocation) {
-        GeoPoint location = new GeoPoint(driverLocation.lat().doubleValue(), driverLocation.lng().doubleValue());
-        DriverLocationDocument locationDocument = new DriverLocationDocument(driverId, location);
-        driverLocationRepository.save(locationDocument);
+    public void update(String username, DriverLocation driverLocation) {
+        driverRepository.findByUsername(username)
+            .map(Driver::getId)
+            .map(driverId -> {
+                GeoPoint location = new GeoPoint(
+                    driverLocation.lat().doubleValue(),
+                    driverLocation.lng().doubleValue()
+                );
+                return new DriverLocationDocument(driverId, location);
+            })
+            .ifPresentOrElse(
+                driverLocationRepository::save,
+                () -> {
+                    throw new DriverNotFoundException(ErrorMessages.DRIVER_NOT_FOUND);
+                }
+            );
     }
 
 }


### PR DESCRIPTION
Changes:

* No more need to put `driverId` in URI to update location data.

---

### Progress

- [x] Change must be properly reviewed (1 review required)
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue

- [86c1pq7t4](https://app.clickup.com/t/86c1pq7t4): Refactor Geolocation Update Endpoint to Use Bearer Token Authentication

### Reviewers

- [Dzmitry Dzivin](https://github.com/dzmitrydzivin)
