### PR TITLE
86c1w4kq9: Bump Github Actions Artifact Actions to v4

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,3 @@
-# top-most EditorConfig file
 root = true
 
 [*]

--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -16,17 +16,17 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
           cache: maven
 
       - name: Cache Maven dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.m2/repository
           key: maven-${{ runner.os }}-${{ hashFiles('**/pom.xml') }}
@@ -40,7 +40,7 @@ jobs:
         run: mvn -B package -DskipTests --file pom.xml
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: java-app
           path: '**/target/*.jar'


### PR DESCRIPTION
Starting January 30th, 2025, GitHub Actions customers will no longer be able to use v3 of [actions/upload-artifact](https://github.com/actions/upload-artifact) or [actions/download-artifact](https://github.com/actions/download-artifact).

More info [there.](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/)

Changes:

* Github Actions Artifact Actions version has been bumped to v4.

---

### Progress

- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue

- [86c1w4kq9](https://app.clickup.com/t/86c1w4kq9): Bump Github Actions Artifact Actions to v4
